### PR TITLE
Make sure the gpio tool is installed

### DIFF
--- a/ppp_installer/install.sh
+++ b/ppp_installer/install.sh
@@ -80,8 +80,8 @@ fi
 #	esac
 #done
 #'
-echo "${YELLOW}ppp install${SET}"
-apt-get install ppp
+echo "${YELLOW}ppp and wiringpi (gpio tool) install${SET}"
+apt-get install ppp wiringpi
 
 echo "${YELLOW}What is your carrier APN?${SET}"
 read carrierapn 


### PR DESCRIPTION
My freshly installed raspbian lacked the gpio tool used in the reconnect script.
Please also include this installation (part of the wiringpi package)